### PR TITLE
Make `obs-pack` executable

### DIFF
--- a/obs-pack/obs-pack.py
+++ b/obs-pack/obs-pack.py
@@ -1,3 +1,5 @@
+#!/usr/local/bin/python3
+
 import json
 import tempfile
 import sys

--- a/obs-pack/obs-pack.py
+++ b/obs-pack/obs-pack.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 import json
 import tempfile


### PR DESCRIPTION
This commit adds a shebang to the start of the `obs-pack.py` file to tell the shell which interpreter to use for the file.

This means the file can be marked as executable and run like `./obs-pack.py` on Unix systems (or symlinked somewhere and added to the user's path).